### PR TITLE
Create SettingViewModelHelper

### DIFF
--- a/TechtonicaModLoader/App.xaml.cs
+++ b/TechtonicaModLoader/App.xaml.cs
@@ -85,8 +85,6 @@ namespace TechtonicaModLoader
             Log.Info($"ThunderStore loaded");
 
             mainVeiwModel = new MainViewModel(dialogService, settingsWindowViewModel, userSettings, profileManager, thunderStore, modFilesManager);
-            mainVeiwModel.SelectedModList = userSettings.DefaultModList;
-            mainVeiwModel.SelectedSortOption = userSettings.DefaultModListSortOption;
             Log.Info($"MainViewModel loaded");
             Log.Info($"Running V{ProgramData.ProgramVersion.Major}.{ProgramData.ProgramVersion.Minor}.{ProgramData.ProgramVersion.Build}");
         }

--- a/TechtonicaModLoader/App.xaml.cs
+++ b/TechtonicaModLoader/App.xaml.cs
@@ -80,7 +80,7 @@ namespace TechtonicaModLoader
             modFilesManager = new ModFilesManager(dialogService, profileManager);
             Log.Info("ModFilesManager loaded");
 
-            thunderStore = new ThunderStore(dialogService, profileManager, modFilesManager, settingsWindowViewModel);
+            thunderStore = new ThunderStore(dialogService, profileManager, modFilesManager, userSettings);
             thunderStore.Load();
             Log.Info($"ThunderStore loaded");
 

--- a/TechtonicaModLoader/App.xaml.cs
+++ b/TechtonicaModLoader/App.xaml.cs
@@ -84,9 +84,9 @@ namespace TechtonicaModLoader
             thunderStore.Load();
             Log.Info($"ThunderStore loaded");
 
-            mainVeiwModel = new MainViewModel(dialogService, settingsWindowViewModel, profileManager, thunderStore, modFilesManager);
-            mainVeiwModel.SelectedModList = userSettings?.DefaultModList;
-            mainVeiwModel.SelectedSortOption = userSettings?.DefaultModListSortOption;
+            mainVeiwModel = new MainViewModel(dialogService, settingsWindowViewModel, userSettings, profileManager, thunderStore, modFilesManager);
+            mainVeiwModel.SelectedModList = userSettings.DefaultModList;
+            mainVeiwModel.SelectedSortOption = userSettings.DefaultModListSortOption;
             Log.Info($"MainViewModel loaded");
             Log.Info($"Running V{ProgramData.ProgramVersion.Major}.{ProgramData.ProgramVersion.Minor}.{ProgramData.ProgramVersion.Build}");
         }

--- a/TechtonicaModLoader/MVVM/ViewModels/Settings/ButtonSetting.cs
+++ b/TechtonicaModLoader/MVVM/ViewModels/Settings/ButtonSetting.cs
@@ -28,7 +28,7 @@ namespace TechtonicaModLoader.MVVM.ViewModels.Settings
 
         // Constructors
 
-        public ButtonSetting(string name, string description, string category, bool isVisible, string buttonText, Action<UserSettings> onClick, UserSettings userSettings) : base(name, description, category, isVisible) {
+        public ButtonSetting(string name, string description, string category, string buttonText, Action<UserSettings> onClick, UserSettings userSettings) : base(name, description, category) {
             ButtonText = buttonText;
             OnClick = onClick;
             this.userSettings = userSettings;

--- a/TechtonicaModLoader/MVVM/ViewModels/Settings/ButtonSetting.cs
+++ b/TechtonicaModLoader/MVVM/ViewModels/Settings/ButtonSetting.cs
@@ -1,9 +1,4 @@
 ﻿using CommunityToolkit.Mvvm.Input;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using TechtonicaModLoader.Stores;
 
 namespace TechtonicaModLoader.MVVM.ViewModels.Settings

--- a/TechtonicaModLoader/MVVM/ViewModels/Settings/ComparableSetting.cs
+++ b/TechtonicaModLoader/MVVM/ViewModels/Settings/ComparableSetting.cs
@@ -42,7 +42,7 @@ namespace TechtonicaModLoader.MVVM.ViewModels.Settings
 
         // Constructors
 
-        public ComparableSetting(string name, string description, string category, bool isVisible, Func<T> getValueFunc, Action<T> setValueFunc, T min, T max) : base(name, description, category, isVisible) {
+        public ComparableSetting(string name, string description, string category, Func<T> getValueFunc, Action<T> setValueFunc, T min, T max) : base(name, description, category) {
             getValue = getValueFunc;
             setValue = setValueFunc;
 

--- a/TechtonicaModLoader/MVVM/ViewModels/Settings/ComparableSetting.cs
+++ b/TechtonicaModLoader/MVVM/ViewModels/Settings/ComparableSetting.cs
@@ -1,18 +1,12 @@
-﻿using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿
 namespace TechtonicaModLoader.MVVM.ViewModels.Settings
 {
     public class ComparableSetting<T> : SettingBase where T : IComparable
     {
         // Members
         
-        private Func<T> getValue;
-        private Action<T> setValue;
+        private readonly Func<T> getValue;
+        private readonly Action<T> setValue;
 
         private static readonly Type[] typesToCheck = [typeof(int), typeof(float), typeof(double)];
 

--- a/TechtonicaModLoader/MVVM/ViewModels/Settings/EnumSetting.cs
+++ b/TechtonicaModLoader/MVVM/ViewModels/Settings/EnumSetting.cs
@@ -1,16 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿
 namespace TechtonicaModLoader.MVVM.ViewModels.Settings
 {
     public class EnumSetting<T> : SettingBase where T : Enum
     {
         // Members
-        private Func<T> getValue;
-        private Action<T> setValue;
+        private readonly Func<T> getValue;
+        private readonly Action<T> setValue;
 
         // Properties
 

--- a/TechtonicaModLoader/MVVM/ViewModels/Settings/EnumSetting.cs
+++ b/TechtonicaModLoader/MVVM/ViewModels/Settings/EnumSetting.cs
@@ -23,7 +23,7 @@ namespace TechtonicaModLoader.MVVM.ViewModels.Settings
 
         // Constructors
 
-        public EnumSetting(string name, string description, string category, bool isVisible, Func<T> getValueFunc, Action<T> setValueFunc) : base(name, description, category, isVisible) {
+        public EnumSetting(string name, string description, string category, Func<T> getValueFunc, Action<T> setValueFunc) : base(name, description, category) {
             getValue = getValueFunc;
             setValue = setValueFunc;
         }

--- a/TechtonicaModLoader/MVVM/ViewModels/Settings/Setting.cs
+++ b/TechtonicaModLoader/MVVM/ViewModels/Settings/Setting.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿
 namespace TechtonicaModLoader.MVVM.ViewModels.Settings
 {
     public class Setting<T> : SettingBase

--- a/TechtonicaModLoader/MVVM/ViewModels/Settings/Setting.cs
+++ b/TechtonicaModLoader/MVVM/ViewModels/Settings/Setting.cs
@@ -21,7 +21,7 @@ namespace TechtonicaModLoader.MVVM.ViewModels.Settings
 
         // Constructors
 
-        public Setting(string name, string description, string category, bool isVisible, Func<T> getValueFunc, Action<T> setValueFunc) : base(name, description, category, isVisible) {
+        public Setting(string name, string description, string category, Func<T> getValueFunc, Action<T> setValueFunc) : base(name, description, category) {
             getValue = getValueFunc;
             setValue = setValueFunc;
         }

--- a/TechtonicaModLoader/MVVM/ViewModels/Settings/SettingBase.cs
+++ b/TechtonicaModLoader/MVVM/ViewModels/Settings/SettingBase.cs
@@ -1,9 +1,4 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TechtonicaModLoader.MVVM.ViewModels.Settings
 {
@@ -14,15 +9,18 @@ namespace TechtonicaModLoader.MVVM.ViewModels.Settings
         public string Name { get; }
         public string Description { get; }
         public string Category { get; }
-        public bool IsVisible { get; }
 
         // Constructors
 
-        public SettingBase(string name, string description, string category, bool isVisible) {
+        public SettingBase(string name, string description, string category) {
             Name = name;
             Description = description;
             Category = category;
-            IsVisible = isVisible;
+
+            if (!Description.EndsWith('.')) {
+                Description += '.';
+            }
+
         }
     }
 }

--- a/TechtonicaModLoader/MVVM/ViewModels/Settings/SettingViewModelHelper.cs
+++ b/TechtonicaModLoader/MVVM/ViewModels/Settings/SettingViewModelHelper.cs
@@ -1,0 +1,131 @@
+﻿using Microsoft.Win32;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.IO;
+using TechtonicaModLoader.Services;
+using TechtonicaModLoader.Stores;
+
+namespace TechtonicaModLoader.MVVM.ViewModels.Settings
+{
+    internal class SettingViewModelHelper 
+    {
+        // Properties
+        public List<SettingBase> SettingViewModels { get; } = [];
+
+        public string DefaultCategory { get; }
+
+        public Setting<bool> LogDebugMessages { get; }
+        public ButtonSetting ShowLogInExplorer { get; }
+
+        public Setting<string> GameFolder { get; }
+        public ButtonSetting FindGameFolder { get; }
+        public ButtonSetting BrowseForGameFolder { get; }
+
+        public EnumSetting<ModListSource> DefaultModList { get; }
+        public EnumSetting<ModListSortOption> DefaultModListSortOption { get; }
+
+        internal SettingViewModelHelper(UserSettings userSettings, IDialogService dialogService, Action settingChanged, string defaultCategory) {
+
+            // General
+
+            DefaultCategory = defaultCategory;
+
+            LogDebugMessages = new Setting<bool>(
+                name: "Log Debug Messages",
+                description: "Whether debug messages should be logged to file. Enable to gather info for a bug report.",
+                category: DefaultCategory,
+                getValueFunc: () => userSettings.LogDebugMessages,
+                setValueFunc: value => userSettings.LogDebugMessages = value
+            );
+
+            ShowLogInExplorer = new ButtonSetting(
+                name: "Show Log In Explorer",
+                description: "Opens the folder that contains Techtonica Mod Loader's log file.",
+                category: DefaultCategory,
+                buttonText: "Show In Explorer",
+                userSettings: userSettings,
+                onClick: delegate (UserSettings settings) {
+                    Process.Start(new ProcessStartInfo() {
+                        FileName = ProgramData.FilePaths.LogsFolder,
+                        UseShellExecute = true,
+                        Verb = "open"
+                    });
+                }
+            );
+
+            // Game Folder
+
+            GameFolder = new Setting<string>(
+                name: "Game Folder",
+                description: "Techtonica's Installation Location.",
+                category: "Game Folder",
+                getValueFunc: () => userSettings.GameFolder,
+                setValueFunc: value => userSettings.GameFolder = value
+            );
+
+            FindGameFolder = new ButtonSetting(
+                name: "Find Game Folder",
+                description: "Have Techtonica Mod Loader search for your Techtonica installation folder.",
+                category: "Game Folder",
+                buttonText: "Find",
+                userSettings: userSettings,
+                onClick: delegate (UserSettings settings) {
+                    // ToDo: Find Game Folder
+                }
+            );
+
+            BrowseForGameFolder = new ButtonSetting(
+                name: "Browse For Game Folder",
+                description: "Manually browse for Techtonica's installation location.",
+                category: "Game Folder",
+                buttonText: "Browse",
+                userSettings: userSettings,
+                onClick: delegate (UserSettings settings) {
+
+                    //TODO: ***** This needs to be refactored to remove OpenFileDialog from the ViewModel ******
+                    //   How?  IDialogService seems like an interesting place to add a method for this.   May want to think about making any new method resuable for other scenarios.
+                    //   I set up the code here for refactoring, regardless of how its done.  
+
+                    OpenFileDialog browser = new() { Filter = "Techtonica.exe|*.exe" };
+                    if (browser.ShowDialog() == true) {
+                        if (browser.FileName.EndsWith("Techtonica.exe")) {
+                            userSettings.GameFolder = Path.GetDirectoryName(browser.FileName) ?? "";
+                            settingChanged();
+                        }
+                        else {
+                            dialogService.ShowErrorMessage("Wrong File Selected", "You need to select the file 'Techtonica.exe'");
+                        }
+                    }
+                }
+            );
+
+            // Mod List
+
+            DefaultModList = new EnumSetting<ModListSource>(
+                name: "Default Mod List",
+                description: "The mod list that is displayed when you open Techtonica Mod Loader.",
+                category: "Mod List",
+                getValueFunc: () => userSettings.DefaultModList,
+                setValueFunc: value => userSettings.DefaultModList = value
+            );
+
+            DefaultModListSortOption = new EnumSetting<ModListSortOption>(
+                name: "Default Sort Option",
+                description: "The default sort option to apply to the mod list.",
+                category: "Mod List",
+                getValueFunc: () => userSettings.DefaultModListSortOption,
+                setValueFunc: value => userSettings.DefaultModListSortOption = value
+            );
+
+            SettingViewModels.Add(LogDebugMessages);
+            SettingViewModels.Add(ShowLogInExplorer);
+
+            SettingViewModels.Add(GameFolder);
+            SettingViewModels.Add(FindGameFolder);
+            SettingViewModels.Add(BrowseForGameFolder);
+
+            SettingViewModels.Add(DefaultModList);
+            SettingViewModels.Add(DefaultModListSortOption);
+        }
+    }
+}

--- a/TechtonicaModLoader/MVVM/ViewModels/Settings/SettingViewModelHelper.cs
+++ b/TechtonicaModLoader/MVVM/ViewModels/Settings/SettingViewModelHelper.cs
@@ -13,31 +13,21 @@ namespace TechtonicaModLoader.MVVM.ViewModels.Settings
 
         public string DefaultCategory { get; }
 
-        public Setting<bool> LogDebugMessages { get; }
-        public ButtonSetting ShowLogInExplorer { get; }
-
-        public Setting<string> GameFolder { get; }
-        public ButtonSetting FindGameFolder { get; }
-        public ButtonSetting BrowseForGameFolder { get; }
-
-        public EnumSetting<ModListSource> DefaultModList { get; }
-        public EnumSetting<ModListSortOption> DefaultModListSortOption { get; }
-
         internal SettingViewModelHelper(UserSettings userSettings, IDialogService dialogService, Action settingChanged, string defaultCategory) {
-
-            // General
 
             DefaultCategory = defaultCategory;
 
-            LogDebugMessages = new Setting<bool>(
+            // General
+
+            SettingViewModels.Add(new Setting<bool>(
                 name: "Log Debug Messages",
                 description: "Whether debug messages should be logged to file. Enable to gather info for a bug report.",
                 category: DefaultCategory,
                 getValueFunc: () => userSettings.LogDebugMessages,
                 setValueFunc: value => userSettings.LogDebugMessages = value
-            );
+            ));
 
-            ShowLogInExplorer = new ButtonSetting(
+            SettingViewModels.Add(new ButtonSetting(
                 name: "Show Log In Explorer",
                 description: "Opens the folder that contains Techtonica Mod Loader's log file.",
                 category: DefaultCategory,
@@ -50,19 +40,19 @@ namespace TechtonicaModLoader.MVVM.ViewModels.Settings
                         Verb = "open"
                     });
                 }
-            );
+            ));
 
             // Game Folder
 
-            GameFolder = new Setting<string>(
+            SettingViewModels.Add(new Setting<string>(
                 name: "Game Folder",
                 description: "Techtonica's Installation Location.",
                 category: "Game Folder",
                 getValueFunc: () => userSettings.GameFolder,
                 setValueFunc: value => userSettings.GameFolder = value
-            );
+            ));
 
-            FindGameFolder = new ButtonSetting(
+            SettingViewModels.Add(new ButtonSetting(
                 name: "Find Game Folder",
                 description: "Have Techtonica Mod Loader search for your Techtonica installation folder.",
                 category: "Game Folder",
@@ -71,9 +61,9 @@ namespace TechtonicaModLoader.MVVM.ViewModels.Settings
                 onClick: delegate (UserSettings settings) {
                     // ToDo: Find Game Folder
                 }
-            );
+            ));
 
-            BrowseForGameFolder = new ButtonSetting(
+            SettingViewModels.Add(new ButtonSetting(
                 name: "Browse For Game Folder",
                 description: "Manually browse for Techtonica's installation location.",
                 category: "Game Folder",
@@ -96,35 +86,25 @@ namespace TechtonicaModLoader.MVVM.ViewModels.Settings
                         }
                     }
                 }
-            );
+            ));
 
             // Mod List
 
-            DefaultModList = new EnumSetting<ModListSource>(
+            SettingViewModels.Add(new EnumSetting<ModListSource>(
                 name: "Default Mod List",
                 description: "The mod list that is displayed when you open Techtonica Mod Loader.",
                 category: "Mod List",
                 getValueFunc: () => userSettings.DefaultModList,
                 setValueFunc: value => userSettings.DefaultModList = value
-            );
+            ));
 
-            DefaultModListSortOption = new EnumSetting<ModListSortOption>(
+            SettingViewModels.Add(new EnumSetting<ModListSortOption>(
                 name: "Default Sort Option",
                 description: "The default sort option to apply to the mod list.",
                 category: "Mod List",
                 getValueFunc: () => userSettings.DefaultModListSortOption,
                 setValueFunc: value => userSettings.DefaultModListSortOption = value
-            );
-
-            SettingViewModels.Add(LogDebugMessages);
-            SettingViewModels.Add(ShowLogInExplorer);
-
-            SettingViewModels.Add(GameFolder);
-            SettingViewModels.Add(FindGameFolder);
-            SettingViewModels.Add(BrowseForGameFolder);
-
-            SettingViewModels.Add(DefaultModList);
-            SettingViewModels.Add(DefaultModListSortOption);
+            ));
         }
     }
 }

--- a/TechtonicaModLoader/MVVM/ViewModels/Settings/SettingViewModelHelper.cs
+++ b/TechtonicaModLoader/MVVM/ViewModels/Settings/SettingViewModelHelper.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Win32;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using TechtonicaModLoader.Services;

--- a/TechtonicaModLoader/MainViewModel.cs
+++ b/TechtonicaModLoader/MainViewModel.cs
@@ -195,7 +195,7 @@ namespace TechtonicaModLoader.MVVM
             IEnumerable<Mod> allMods = thunderStore.ModCache.Where(mod => mod.FullName.ToLower().Contains(SearchTerm.ToLower()));
 
             switch (SelectedModList) {
-                case ModListSource.New: allMods = allMods.Where(mod => !settingsWindowViewModel.SeenMods.Contains(mod.ID)); break;
+                case ModListSource.New: allMods = allMods.Where(mod => !userSettings.SeenMods.Contains(mod.ID)); break;
                 case ModListSource.Downloaded: allMods = allMods.Where(mod => mod.IsDownloaded); break;
                 case ModListSource.NotDownloaded: allMods = allMods.Where(mod => !mod.IsDownloaded); break;
                 case ModListSource.Enabled: allMods = allMods.Where(mod => mod.IsDownloaded && mod.IsEnabled); break;

--- a/TechtonicaModLoader/MainViewModel.cs
+++ b/TechtonicaModLoader/MainViewModel.cs
@@ -30,8 +30,8 @@ namespace TechtonicaModLoader.MVVM
         public string Title => $"Techtonica Mod Loader - V{ProgramVersion.Major}.{ProgramVersion.Minor}.{ProgramVersion.Build}";
 
         [ObservableProperty] private bool _modUpdatesAvailable = false;
-        [ObservableProperty] private ModListSource _selectedModList = ModListSource.New;
-        [ObservableProperty] private ModListSortOption _selectedSortOption = ModListSortOption.Newest;
+        [ObservableProperty] private ModListSource _selectedModList;
+        [ObservableProperty] private ModListSortOption _selectedSortOption;
         [ObservableProperty] private string _searchTerm = "";
         [ObservableProperty] private ObservableCollection<ModViewModel> _modsToShow;
 
@@ -67,6 +67,9 @@ namespace TechtonicaModLoader.MVVM
             this.thunderStore = thunderStore;
             this.modFilesManager = modFilesManager;
             this.userSettings = userSettings;
+
+            _selectedModList = userSettings.DefaultModList;
+            _selectedSortOption = userSettings.DefaultModListSortOption;
 
             profileManager.PropertyChanged += OnProfileManagerPropertyChanged;
             thunderStore.PropertyChanged += OnThunderstorePropertyChanged;

--- a/TechtonicaModLoader/MainViewModel.cs
+++ b/TechtonicaModLoader/MainViewModel.cs
@@ -201,7 +201,7 @@ namespace TechtonicaModLoader.MVVM
             IEnumerable<Mod> allMods = thunderStore.ModCache.Where(mod => mod.FullName.ToLower().Contains(SearchTerm.ToLower()));
 
             switch (SelectedModList) {
-                case ModListSource.New: allMods = allMods.Where(mod => !settingsWindowViewModel.SeenMods.Value.Contains(mod.ID)); break;
+                case ModListSource.New: allMods = allMods.Where(mod => !settingsWindowViewModel.SeenMods.Contains(mod.ID)); break;
                 case ModListSource.Downloaded: allMods = allMods.Where(mod => mod.IsDownloaded); break;
                 case ModListSource.NotDownloaded: allMods = allMods.Where(mod => !mod.IsDownloaded); break;
                 case ModListSource.Enabled: allMods = allMods.Where(mod => mod.IsDownloaded && mod.IsEnabled); break;

--- a/TechtonicaModLoader/Services/Thunderstore.cs
+++ b/TechtonicaModLoader/Services/Thunderstore.cs
@@ -1,23 +1,13 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Configuration;
 using System.IO;
-using System.Linq;
-using System.Net;
 using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Media.Imaging;
-using System.Xml.Linq;
 using TechtonicaModLoader.MVVM.Models;
 using TechtonicaModLoader.Services.ThunderstoreModels;
 using TechtonicaModLoader.Stores;
-using TechtonicaModLoader.Windows.Settings;
 
 namespace TechtonicaModLoader.Services
 {
@@ -54,7 +44,7 @@ namespace TechtonicaModLoader.Services
         private IDialogService dialogService;
         private IProfileManager profileManager;
         private IModFilesManager modFilesManager;
-        private SettingsWindowViewModel settingsWindowViewModel;
+        private IUserSettings userSettings;
 
         private List<Mod> _modCache = new List<Mod>();
 
@@ -66,12 +56,12 @@ namespace TechtonicaModLoader.Services
 
         // Constructors
 
-        public ThunderStore(IDialogService dialogService, IProfileManager profileManager, IModFilesManager modFilesManager, SettingsWindowViewModel settingsWindowViewModel) 
+        public ThunderStore(IDialogService dialogService, IProfileManager profileManager, IModFilesManager modFilesManager, IUserSettings settings) 
         {
             this.dialogService = dialogService;
             this.profileManager = profileManager;
             this.modFilesManager = modFilesManager;
-            this.settingsWindowViewModel = settingsWindowViewModel;
+            userSettings = settings;
             StartUpdateThread();
             StartDownloadThread();
         }
@@ -93,7 +83,7 @@ namespace TechtonicaModLoader.Services
 
             modFilesManager.ProcessZipFile(zipFileLocation, thunderStoreMod);
 
-            settingsWindowViewModel.DeployNeeded = true;
+            userSettings.DeployNeeded = true;
         }
 
         // Public Functions

--- a/TechtonicaModLoader/Windows/Settings/SettingsWindowViewModel.cs
+++ b/TechtonicaModLoader/Windows/Settings/SettingsWindowViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using System.Collections.ObjectModel;
 using TechtonicaModLoader.MVVM.ViewModels.Settings;
 using TechtonicaModLoader.Services;
 using TechtonicaModLoader.Stores;

--- a/TechtonicaModLoader/Windows/Settings/SettingsWindowViewModel.cs
+++ b/TechtonicaModLoader/Windows/Settings/SettingsWindowViewModel.cs
@@ -1,14 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Microsoft.Win32;
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using TechtonicaModLoader.MVVM.ViewModels.Settings;
 using TechtonicaModLoader.Services;
 using TechtonicaModLoader.Stores;
@@ -21,44 +13,47 @@ namespace TechtonicaModLoader.Windows.Settings
 
         private const string defaultCategory = "General";
 
-        private UserSettings? userSettings;
-        private IDialogService dialogService;
-
-        private ObservableCollection<SettingBase> _settingViewModels = new ObservableCollection<SettingBase>();
+        private readonly UserSettings userSettings;
+        private readonly SettingViewModelHelper settingViewModelHelper;
 
         // Properties
 
-        public ObservableCollection<SettingBase> SettingViewModels => _settingViewModels;
         public IEnumerable<SettingBase> SettingsToShow {
             get {
                 return SettingViewModels.Where(setting => 
-                    setting.Category == SelectedItem && 
-                    setting.IsVisible
+                    setting.Category == SelectedItem
                 );
             }
         }
+
         public IEnumerable<string> Categories {
             get {
                 return SettingViewModels
-                      .Where(setting => setting.IsVisible)
                       .Select(setting => setting.Category)
                       .Distinct();
             }
         }
 
-        public Setting<bool> LogDebugMessages { get; }
-        public ButtonSetting ShowLogInExplorer { get; }
-        
-        public Setting<string> GameFolder { get; }
-        public ButtonSetting FindGameFolder { get; }
-        public ButtonSetting BrowseForGameFolder { get; }
-        
-        public EnumSetting<ModListSource> DefaultModList { get; }
-        public EnumSetting<ModListSortOption> DefaultModListSortOption { get; }
+        public List<SettingBase> SettingViewModels => settingViewModelHelper.SettingViewModels;
 
-        public ComparableSetting<int> ActiveProfileID { get; }
-        public Setting<bool> DeployNeededSetting { get; }
-        public Setting<List<string>> SeenMods { get; }
+        // TODO: Follow up to see if these can be removed and dependencies can consume IUserSettings instead.
+        //   The View only consumes the SettingViewModels property above so removing access to the individual VMs would reduce complexity.
+
+        public Setting<bool> LogDebugMessages => settingViewModelHelper.LogDebugMessages;
+        public ButtonSetting ShowLogInExplorer => settingViewModelHelper.ShowLogInExplorer;
+        
+        public Setting<string> GameFolder => settingViewModelHelper.GameFolder;
+        public ButtonSetting FindGameFolder => settingViewModelHelper.FindGameFolder;
+        public ButtonSetting BrowseForGameFolder => settingViewModelHelper.BrowseForGameFolder;
+        
+        public EnumSetting<ModListSource> DefaultModList => settingViewModelHelper.DefaultModList;
+        public EnumSetting<ModListSortOption> DefaultModListSortOption => settingViewModelHelper.DefaultModListSortOption;
+
+
+
+        public int ActiveProfileID => userSettings.ActiveProfileID;
+        public bool DeployNeededSetting => userSettings.DeployNeeded;
+        public List<string> SeenMods => userSettings.SeenMods;
 
         [ObservableProperty] string _selectedItem = defaultCategory;
         [ObservableProperty] bool _deployNeeded = false;
@@ -67,144 +62,7 @@ namespace TechtonicaModLoader.Windows.Settings
 
         public SettingsWindowViewModel(UserSettings userSettings, IDialogService dialogService) {
             this.userSettings = userSettings;
-            this.dialogService = dialogService;
-
-            // General
-
-            LogDebugMessages = new Setting<bool>(
-                name: "Log Debug Messages",
-                description: "Whether debug messages should be logged to file. Enable to gather info for a bug report.",
-                category: defaultCategory,
-                isVisible: true,
-                getValueFunc: () => userSettings.LogDebugMessages,
-                setValueFunc: value => userSettings.LogDebugMessages = value
-            );
-
-            ShowLogInExplorer = new ButtonSetting(
-                name: "Show Log In Explorer",
-                description: "Opens the folder that contains Techtonica Mod Loader's log file.",
-                category: defaultCategory,
-                isVisible: true,
-                buttonText: "Show In Explorer",
-                userSettings: userSettings,
-                onClick: delegate (UserSettings settings) {
-                    Process.Start(new ProcessStartInfo() {
-                        FileName = ProgramData.FilePaths.LogsFolder,
-                        UseShellExecute = true,
-                        Verb = "open"
-                    });
-                }
-            );
-
-            // Game Folder
-
-            GameFolder = new Setting<string>(
-                name: "Game Folder",
-                description: "Techtonica's Installation Location.",
-                category: "Game Folder",
-                isVisible: true,
-                getValueFunc: () => userSettings.GameFolder,
-                setValueFunc: value => userSettings.GameFolder = value
-            );
-
-            FindGameFolder = new ButtonSetting(
-                name: "Find Game Folder",
-                description: "Have Techtonica Mod Loader search for your Techtonica installation folder.",
-                category: "Game Folder",
-                isVisible: true,
-                buttonText: "Find",
-                userSettings: userSettings,
-                onClick: delegate (UserSettings settings) {
-                    // ToDo: Find Game Folder
-                }
-            );
-
-            BrowseForGameFolder = new ButtonSetting(
-                name: "Browse For Game Folder",
-                description: "Manually browse for Techtonica's installation location.",
-                category: "Game Folder",
-                isVisible: true,
-                buttonText: "Browse",
-                userSettings: userSettings,
-                onClick: delegate(UserSettings settings) {
-                    OpenFileDialog browser = new OpenFileDialog { Filter = ("Techtonica.exe|*.exe") };
-                    if (browser.ShowDialog() == true) {
-                        if (browser.FileName.EndsWith("Techtonica.exe")) {
-                            userSettings.GameFolder = Path.GetDirectoryName(browser.FileName) ?? "";
-                            OnPropertyChanged(nameof(SettingsToShow));
-                        }
-                        else {
-                            dialogService.ShowErrorMessage("Wrong File Selected", "You need to select the file 'Techtonica.exe'");
-                        }
-                    }
-                }
-            );
-
-            // Mod List
-
-            DefaultModList = new EnumSetting<ModListSource>(
-                name: "Default Mod List",
-                description: "The mod list that is displayed when you open Techtonica Mod Loader.",
-                category: "Mod List",
-                isVisible: true,
-                getValueFunc: () => userSettings.DefaultModList,
-                setValueFunc: value => userSettings.DefaultModList = value
-            );
-
-            DefaultModListSortOption = new EnumSetting<ModListSortOption>(
-                name: "Default Sort Option",
-                description: "The default sort option to apply to the mod list.",
-                category: "Mod List",
-                isVisible: true,
-                getValueFunc: () => userSettings.DefaultModListSortOption,
-                setValueFunc: value => userSettings.DefaultModListSortOption = value
-            );
-
-            // Hidden
-
-            ActiveProfileID = new ComparableSetting<int>(
-                name: "ActiveProfileID",
-                description: "",
-                category: defaultCategory,
-                isVisible: false,
-                getValueFunc: () => userSettings.ActiveProfileID,
-                setValueFunc: value => userSettings.ActiveProfileID = value,
-                min: 0,
-                max: int.MaxValue
-            );
-
-            DeployNeededSetting = new Setting<bool>(
-                name: "Deploy Needed",
-                description: "",
-                category: defaultCategory,
-                isVisible: false,
-                getValueFunc: () => userSettings.DeployNeeded,
-                setValueFunc: value => userSettings.DeployNeeded = value
-            );
-
-            SeenMods = new Setting<List<string>>(
-                name: "SeenMods",
-                description: "",
-                category: defaultCategory,
-                isVisible: false,
-                getValueFunc: () => userSettings.SeenMods,
-                setValueFunc: value => userSettings.SeenMods = value
-            );
-
-            _settingViewModels.Add(LogDebugMessages);
-            _settingViewModels.Add(ShowLogInExplorer);
-
-            _settingViewModels.Add(GameFolder);
-            _settingViewModels.Add(FindGameFolder);
-            _settingViewModels.Add(BrowseForGameFolder);
-
-            _settingViewModels.Add(DefaultModList);
-            _settingViewModels.Add(DefaultModListSortOption);
-
-            _settingViewModels.Add(ActiveProfileID);
-            _settingViewModels.Add(SeenMods);
-
-            ValidateSettings();
+            settingViewModelHelper = new(this.userSettings, dialogService, SettingChanged, defaultCategory: "General");
         }
 
         // Commands
@@ -224,19 +82,11 @@ namespace TechtonicaModLoader.Windows.Settings
 
         // Private Functions
 
-        private void ValidateSettings() {
-            foreach(SettingBase setting in _settingViewModels) {
-                if (setting.IsVisible && !setting.Description.EndsWith(".")) {
-                    throw new Exception($"Setting \"{setting.Name}\"'s Description Property doesn't end with '.'");
-                }
-
-                if(!setting.IsVisible && setting.Category != defaultCategory) {
-                    throw new Exception($"Setting \"{setting.Name}\" is hidden, but it's Category property isn't default ('{defaultCategory}')");
-                }
-            }
+        partial void OnSelectedItemChanged(string value) {
+            OnPropertyChanged(nameof(SettingsToShow));
         }
 
-        partial void OnSelectedItemChanged(string value) {
+        private void SettingChanged() {
             OnPropertyChanged(nameof(SettingsToShow));
         }
     }

--- a/TechtonicaModLoader/Windows/Settings/SettingsWindowViewModel.cs
+++ b/TechtonicaModLoader/Windows/Settings/SettingsWindowViewModel.cs
@@ -35,10 +35,6 @@ namespace TechtonicaModLoader.Windows.Settings
 
         public List<SettingBase> SettingViewModels => settingViewModelHelper.SettingViewModels;
 
-        public int ActiveProfileID => userSettings.ActiveProfileID;
-        public bool DeployNeededSetting => userSettings.DeployNeeded;
-        public List<string> SeenMods => userSettings.SeenMods;
-
         [ObservableProperty] string _selectedItem = defaultCategory;
         [ObservableProperty] bool _deployNeeded = false;
 
@@ -46,7 +42,7 @@ namespace TechtonicaModLoader.Windows.Settings
 
         public SettingsWindowViewModel(UserSettings userSettings, IDialogService dialogService) {
             this.userSettings = userSettings;
-            settingViewModelHelper = new(this.userSettings, dialogService, SettingChanged, defaultCategory: "General");
+            settingViewModelHelper = new(this.userSettings, dialogService, SettingChanged, defaultCategory);
         }
 
         // Commands

--- a/TechtonicaModLoader/Windows/Settings/SettingsWindowViewModel.cs
+++ b/TechtonicaModLoader/Windows/Settings/SettingsWindowViewModel.cs
@@ -35,21 +35,6 @@ namespace TechtonicaModLoader.Windows.Settings
 
         public List<SettingBase> SettingViewModels => settingViewModelHelper.SettingViewModels;
 
-        // TODO: Follow up to see if these can be removed and dependencies can consume IUserSettings instead.
-        //   The View only consumes the SettingViewModels property above so removing access to the individual VMs would reduce complexity.
-
-        public Setting<bool> LogDebugMessages => settingViewModelHelper.LogDebugMessages;
-        public ButtonSetting ShowLogInExplorer => settingViewModelHelper.ShowLogInExplorer;
-        
-        public Setting<string> GameFolder => settingViewModelHelper.GameFolder;
-        public ButtonSetting FindGameFolder => settingViewModelHelper.FindGameFolder;
-        public ButtonSetting BrowseForGameFolder => settingViewModelHelper.BrowseForGameFolder;
-        
-        public EnumSetting<ModListSource> DefaultModList => settingViewModelHelper.DefaultModList;
-        public EnumSetting<ModListSortOption> DefaultModListSortOption => settingViewModelHelper.DefaultModListSortOption;
-
-
-
         public int ActiveProfileID => userSettings.ActiveProfileID;
         public bool DeployNeededSetting => userSettings.DeployNeeded;
         public List<string> SeenMods => userSettings.SeenMods;

--- a/TechtonicaModLoader/Windows/Settings/SettingsWindowViewModel.cs
+++ b/TechtonicaModLoader/Windows/Settings/SettingsWindowViewModel.cs
@@ -49,13 +49,6 @@ namespace TechtonicaModLoader.Windows.Settings
 
         [RelayCommand]
         private void RestoreDefaults() {
-            if(userSettings == null) {
-                string error = "Can't restore defaults for null userSettings";
-                Log.Error(error);
-                DebugUtils.CrashIfDebug(error);
-                return;
-            }
-
             userSettings.RestoreDefaults();
             OnPropertyChanged(nameof(SettingsToShow));
         }


### PR DESCRIPTION
- Move the creation and containment of all Setting VM classes to this new class.
- Remove isVisible from SettingBase and children.
- Make the formerly invisible ViewModel properties into properties that use UserSettings properties directly.
- The SettingViewModels underlying collection was never actually observed so converted into a List.
- Removed SettingsWindowViewModel.ValidateSettings() and moved the  checking of SettingBase.Description to that class's constructor.  Also made it just add the period.
- Removed the properties that accessed the individual SettingBase derived classes as they are not needed.
- To support the previous item, plumbed through an IUserSettings into MainViewModel.  This is a leaner and cleaner approach.